### PR TITLE
Unique variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ This role only requires Ansible version 1.9+ and EC2_FACTS module.
 
 ## Role Variables
 
-Here is a list of all the default variables for this role, which are also available in `defaults/main.yml`.
+This role only uses one variable, `awslogs_logs`, which is a dictionary comprised of the following items:
 
 ```yaml
----
 
-# logs:
-#    - file: /var/log/syslog            (required)
-#      format: "%b %d %H:%M:%S"
-#      time_zone: "LOCAL"
-#      initial_position: "end_of_file"
-#      group_name: syslog               (required)
-#
+awslogs_logs:
+  - file: /var/log/syslog            # The path to the log file you want to ship (required)
+    format: "%b %d %H:%M:%S"         # The date and time format of the log file
+    time_zone: "LOCAL"               # Timezone, can either be LOCAL or UTC
+    initial_position: "end_of_file"  # Where log shipping should start from
+    group_name: syslog               # The Cloudwatch Logs group name (required)
 ```
+
+This configuration is further expanded on in the [Amazon Cloudwatch Logs Documentation](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html#d0e2872).
 
 ## Dependencies
 
@@ -36,8 +36,7 @@ None
 - hosts: all
 
   vars:
-
-    logs:
+    awslogs_logs:
       - file: /var/log/syslog
         format: "%b %d %H:%M:%S"
         time_zone: "LOCAL"
@@ -62,5 +61,3 @@ MIT / BSD
 
 Thiago Gomes
 - thiago.mgomes [at] gmail.com
-
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
-
-#logs:
-#  - file: /var/log/syslog            (required)
-#    format: "%b %d %H:%M:%S"
-#    time_zone: "LOCAL"
-#    initial_position: "end_of_file"
-#    group_name: "syslog"             (required)
+awslogs_logs:
+  - file: /var/log/syslog
+    format: "%b %d %H:%M:%S"
+    time_zone: "LOCAL"
+    initial_position: "end_of_file"
+    group_name: "syslog"

--- a/templates/awslogs.conf.j2
+++ b/templates/awslogs.conf.j2
@@ -116,7 +116,7 @@ encoding = utf-8 # Other supported encodings include: ascii, latin-1
 #  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
 # ----------------------------------------------------------------------------------------------------------------------
 
-{% for log in logs %}
+{% for log in awslogs_logs %}
 [{{ log.file }}]
 {% if log.time_zone is defined %}
 time_zone = {{ log.time_zone }}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,7 @@
 
   vars:
 
-    logs:
+    awslogs_logs:
       - file: /var/log/syslog
         format: "%b %d %H:%M:%S"
         time_zone: "LOCAL"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for .


### PR DESCRIPTION
Awesome role! I have updated it a little:
- I renamed the only variable you used so that it's unique - `logs` is used in many roles, but `awslogs_logs` is unambiguous. We needed to change it to implement it ourselves.
- I removed the `vars/` directory since it wasn't being used.
- I removed the comments in `defaults/main.yml` since the defaults are actually useful when nothing else is used.
- I expanded upon the README to take into account my change but also to document each of the items of the `awslogs_logs` dictionary.

This updated role is now in use in our infrastructure, so thanks :)
