### PR TITLE
AWS Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ This role only requires Ansible version 1.9+ and EC2_FACTS module.
 
 ## Role Variables
 
-Here is a list of all the default variables for this role, which are also available in `defaults/main.yml`.
+This role only uses one variable, `awslogs_logs`, which is a dictionary comprised of the following items:
 
 ```yaml
----
 
-# logs:
-#    - file: /var/log/syslog            (required)
-#      format: "%b %d %H:%M:%S"
-#      time_zone: "LOCAL"
-#      initial_position: "end_of_file"
-#      group_name: syslog               (required)
-#
+awslogs_logs:
+  - file: /var/log/syslog            # The path to the log file you want to ship (required)
+    format: "%b %d %H:%M:%S"         # The date and time format of the log file
+    time_zone: "LOCAL"               # Timezone, can either be LOCAL or UTC
+    initial_position: "end_of_file"  # Where log shipping should start from
+    group_name: syslog               # The Cloudwatch Logs group name (required)
 ```
+
+This configuration is further expanded on in the [Amazon Cloudwatch Logs Documentation](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html#d0e2872).
 
 ## Dependencies
 
@@ -36,8 +36,7 @@ None
 - hosts: all
 
   vars:
-
-    logs:
+    awslogs_logs:
       - file: /var/log/syslog
         format: "%b %d %H:%M:%S"
         time_zone: "LOCAL"
@@ -62,5 +61,3 @@ MIT / BSD
 
 Thiago Gomes
 - thiago.mgomes [at] gmail.com
-
-

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Here is a list of all the default variables for this role, which are also availa
 #
 ```
 
+In addition, there are three variables that are not used by default:
+
+```yaml
+awslogs_region: eu-west-1            # Overrides the local region for log shipping
+awslogs_access_key_id: XXX           # AWS key ID, used instead of IAM roles
+awslogs_secret_access_key: XXX       # AWS secret key, used instead of IAM roles
+```
+
 ## Dependencies
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
-
-#logs:
-#  - file: /var/log/syslog            (required)
-#    format: "%b %d %H:%M:%S"
-#    time_zone: "LOCAL"
-#    initial_position: "end_of_file"
-#    group_name: "syslog"             (required)
+awslogs_logs:
+  - file: /var/log/syslog
+    format: "%b %d %H:%M:%S"
+    time_zone: "LOCAL"
+    initial_position: "end_of_file"
+    group_name: "syslog"

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -16,3 +16,9 @@
     owner: root
     group: root
     mode: 0644
+
+- name: "awslogs | configure awslogs credentials"
+  template:
+    src: awscli.conf.j2
+    dest: /var/awslogs/etc/awscli.conf
+  when: awslogs_secret_access_key is defined

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,6 +23,6 @@
   action: ec2_facts
 
 - name: "awslogs | install the daemon"
-  shell: "python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /var/awslogs/etc/awslogs.conf"
+  shell: "python /tmp/awslogs-agent-setup.py -n -r {{ awslogs_region | default(ansible_ec2_placement_region) }} -c /var/awslogs/etc/awslogs.conf"
   args:
     creates: "/etc/init.d/awslogs"

--- a/templates/awscli.conf.j2
+++ b/templates/awscli.conf.j2
@@ -1,0 +1,3 @@
+region = {{ awslogs_region | default(ansible_ec2_placement_region) }}
+aws_access_key_id = {{ awslogs_access_key_id }}
+aws_secret_access_key = {{ awslogs_secret_access_key }}

--- a/templates/awslogs.conf.j2
+++ b/templates/awslogs.conf.j2
@@ -116,7 +116,7 @@ encoding = utf-8 # Other supported encodings include: ascii, latin-1
 #  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
 # ----------------------------------------------------------------------------------------------------------------------
 
-{% for log in logs %}
+{% for log in awslogs_logs %}
 [{{ log.file }}]
 {% if log.time_zone is defined %}
 time_zone = {{ log.time_zone }}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,7 @@
 
   vars:
 
-    logs:
+    awslogs_logs:
       - file: /var/log/syslog
         format: "%b %d %H:%M:%S"
         time_zone: "LOCAL"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for .


### PR DESCRIPTION
Another one: some of our servers didn't have an IAM role applied, so until we could roll the servers we need to apply `awscli` config to the servers. This allows it, and will probably be useful for other people as well.

I also allow people to override the region, if people have servers across multiple regions but want their logs all in one place :)
