### PR TITLE
Adding temporary awslogs.conf

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,6 +19,15 @@
     url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
   when: service_status.stat.exists == false
 
+- name: "awslogs | upload temporary awslogs.conf"
+  template:
+    src: awslogs.conf.j2
+    dest: /tmp/awslogs.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: service_status.stat.exists == false
+
 - name: "awslogs | discover EC2 facts"
   action: ec2_facts
 


### PR DESCRIPTION
I don't know when this started happening (and I don't think I introduced it, but I might be wrong) - this MR fixes it by temporarily pushing `awslogs.conf` to `/tmp` when installing:

```
  File "/tmp/awslogs-agent-setup.py", line 1144, in <module>
    main()
  File "/tmp/awslogs-agent-setup.py", line 1140, in main
    setup.setup_artifacts()
  File "/tmp/awslogs-agent-setup.py", line 707, in setup_artifacts
    self.write_agent_config_file()
  File "/tmp/awslogs-agent-setup.py", line 545, in write_agent_config_file
    shutil.copyfile(self.config_file, AGENT_CONFIG_FILE)
  File "/usr/lib64/python2.7/shutil.py", line 69, in copyfile
    raise Error("`%s` and `%s` are the same file" % (src, dst))
shutil.Error: `/var/awslogs/etc/awslogs.conf` and `/var/awslogs/etc/awslogs.conf` are the same file
```

You already clean this file up in the cleanup script :)