### PR TITLE
Updated permission in conf.yml

### DIFF
--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -4,7 +4,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 755
+    mode: 0755
   with_items:
     - /var/awslogs/state
     - /var/awslogs/etc


### PR DESCRIPTION
/var/awslogs was created with a wrong permission set, and the service is unable to start.