### PR TITLE
Fix some lint warnings

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,14 +18,14 @@
     mode: 0600
     url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
   when: service_status.stat.exists == false
-  
+
 - name: "awslogs | create systemd unit file"
   copy:
     src=awslogs.service
     dest=/lib/systemd/system/awslogs.service
     owner=root
     group=root
-    mode=644
+    mode=0644
     backup=yes
   when: service_status.stat.exists == false and ansible_service_mgr is defined and ansible_service_mgr == "systemd"
 


### PR DESCRIPTION
Trailing whitespace, octal permissions require leading zero (at least in later versions)