### PR TITLE
Add conditional on HTTP proxy config

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -58,3 +58,4 @@
     group: root
     mode: 0644
   notify: restart awslogs
+  when: (awslogs_http_proxy is defined) or (awslogs_https_proxy is defined) or (awslogs_noproxy is defined)


### PR DESCRIPTION
Currently the task fails if you simply consume the role without specifying `awslogs_http_proxy`, `awslogs_https_proxy` or `awslogs_noproxy`, as follows:

```
    ubuntu-18.04: TASK [ansible-role-awslogs : awslogs | configure awslogs proxy configuration] ***
    ubuntu-18.04: fatal: [default]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'awslogs_http_proxy' is undefined"}
    ubuntu-18.04:
    ubuntu-18.04: RUNNING HANDLER [ansible-role-awslogs : restart awslogs] ***********************
    ubuntu-18.04: 	to retry, use: --limit @/var/jenkins_home/workspace/xxxxxx
    ubuntu-18.04:
    ubuntu-18.04: PLAY RECAP *********************************************************************
    ubuntu-18.04: default                    : ok=11   changed=7    unreachable=0    failed=1
```

This PR is so that the playbook doesn't fail if you don't need to use the proxy functionality.