### PR TITLE
do not get ec2_metadata_facts if awslogs_region was specified

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -44,6 +44,7 @@
 
 - name: "awslogs | discover EC2 facts"
   action: ec2_metadata_facts
+  when: awslogs_region is not defined
 
 - name: "awslogs | install the daemon"
   shell: "python /tmp/awslogs-agent-setup.py -n -r {{ awslogs_region | default(ansible_ec2_placement_region) }} -c /tmp/awslogs.conf"


### PR DESCRIPTION
Awslogs can be used on instance which is not deployed in aws.
If an instance is not deployed in aws line 45-46 causes an issue:
```
fatal: [my_magic_hostname]: FAILED! => {"changed": false, "msg": "Failed to retrieve metadata from AWS: Request failed: <urlopen error timed out>", "response": {"msg": "Request failed: <urlopen error timed out>", "status": -1, "url": "http://169.254.169.254/latest/meta-data/"}}
```
We're using ```ansible_ec2_placement_region``` only if ```awslogs_region``` was no provided, so there is no need to run ```ec2_metadata_facts``` if all required values were passed.