### PR TITLE
Add buffer_duration and file_fingerprint_lines options to awslogs.conf

### DIFF
--- a/templates/awslogs.conf.j2
+++ b/templates/awslogs.conf.j2
@@ -128,7 +128,14 @@ datetime_format = {{ log.format }}
 initial_position = {{ log.initial_position }}
 {% endif %}
 file = {{ log.file }}
+{% if log.buffer_duration is defined %}
+buffer_duration = {{ log.buffer_duration }}
+{% else %}
 buffer_duration = 5000
+{% endif %}
+{% if log.file_fingerprint_lines is defined %}
+file_fingerprint_lines = {{ log.file_fingerprint_lines }}
+{% endif %}
 log_group_name = {{ log.group_name }}
 log_stream_name = {{ log.stream_name }}
 {% if log.multi_line_start_pattern is defined %}


### PR DESCRIPTION
Hello thiagomgo!

Thank you for sharing this role. I'm using it, but I missed in some cases some extra configuration. I've added a couple of options for awslogs.conf in the template `awslogs.conf.j2` that I think can be helpful:

 - buffer_duration
 - file_fingerprint_lines

Buffer duration is set to 5000 as default value (just as it was previous to this change) and file_fingerprint_lines are only added if it is defined in `awslogs_logs` variable.

Could you please review and add these changes?
Thank you in advance.